### PR TITLE
Fix docker-compose geth with latest command for running pocket

### DIFF
--- a/integrations/geth/Dockerfile
+++ b/integrations/geth/Dockerfile
@@ -8,4 +8,4 @@ COPY ./entrypoint.sh .
 
 ENTRYPOINT ["./entrypoint.sh"]
 
-CMD ["pocket-node", "start", "-p", "8000", "-o", "/dev/stdout", "-c"]
+CMD ["pocket-node", "start", "-p", "8000", "-h", "-w",  "-o", "/dev/stdout", "-c"]

--- a/integrations/geth/docker-compose.yml
+++ b/integrations/geth/docker-compose.yml
@@ -33,8 +33,8 @@ services:
     image: poktnetwork/pocket-node:geth
     container_name: pocket-node-geth
     restart: on-failure
-    expose:
-      - 8000
+    ports:
+      - "3000:8000" 
     depends_on:
       - geth-rinkeby
       - geth-mainnet


### PR DESCRIPTION
> Using correct command for running latest pokt version in geth integration
> Opening pokt in `127.0.0.1:3000` 